### PR TITLE
join groups

### DIFF
--- a/src/components/groups/groupCard.tsx
+++ b/src/components/groups/groupCard.tsx
@@ -1,11 +1,28 @@
 import React from "react";
 import GroupType from "../../modules/groupType";
-import { Link } from "react-router-dom";
 import {useSelector} from "react-redux";
+import {
+  fetchGroupsByUserId,
+  GroupMember
+} from "../../reducers/group-members-reducer";
+import {createGroupMember} from "../../services/group-members-services";
 
 const GroupCard = (props: GroupType) => {
-  const {currentUser} = useSelector((state: any) => state.auth);
 
+  const {currentUser} = useSelector((state: any) => state.auth);
+  const clickPostHandler = () => {
+    const newGroupMember: GroupMember = {
+      id: new Date().toDateString(),
+      userId: currentUser._id,
+      groupId: props._id.toString(),
+      createdAt: new Date().toDateString()
+    }
+    try {
+      createGroupMember(newGroupMember);
+    } catch (e) {
+      alert(e);
+    }
+  };
     return (
     <div className="card my-3">
       <div className="my-2"> 
@@ -20,12 +37,10 @@ const GroupCard = (props: GroupType) => {
           <p className="card-text">{props.description}</p>
         </div>
         <div className="float-end col-2" >
-          { currentUser != null ? <Link to="#"className="btn btn-lg btn-primary mt-4 rounded-pill">Join</Link> : <p></p>}
+          { currentUser != null ? <button onClick = {clickPostHandler} className="btn btn-lg btn-primary mt-4 rounded-pill">Join</button> : <p></p>}
         </div>
       </div>
     </div>
     );
 };
-
-
 export default GroupCard;

--- a/src/components/groups/groupCard.tsx
+++ b/src/components/groups/groupCard.tsx
@@ -1,24 +1,14 @@
 import React from "react";
 import GroupType from "../../modules/groupType";
 import {useSelector} from "react-redux";
-import {
-  fetchGroupsByUserId,
-  GroupMember
-} from "../../reducers/group-members-reducer";
 import {createGroupMember} from "../../services/group-members-services";
 
 const GroupCard = (props: GroupType) => {
 
   const {currentUser} = useSelector((state: any) => state.auth);
-  const clickPostHandler = () => {
-    const newGroupMember: GroupMember = {
-      id: new Date().toDateString(),
-      userId: currentUser._id,
-      groupId: props._id.toString(),
-      createdAt: new Date().toDateString()
-    }
+  const clickPostHandler = async () => {
     try {
-      createGroupMember(newGroupMember);
+      await createGroupMember(props._id, currentUser._id);
     } catch (e) {
       alert(e);
     }

--- a/src/components/groups/groupCard.tsx
+++ b/src/components/groups/groupCard.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import GroupType from "../../modules/groupType";
 import {useSelector} from "react-redux";
 import {createGroupMember} from "../../services/group-members-services";
+import {Link} from "react-router-dom";
 
 const GroupCard = (props: GroupType) => {
-
   const {currentUser} = useSelector((state: any) => state.auth);
   const clickPostHandler = async () => {
     try {
@@ -14,23 +14,25 @@ const GroupCard = (props: GroupType) => {
     }
   };
     return (
-    <div className="card my-3">
-      <div className="my-2"> 
-        <img 
-          className="card-img mt-2" 
-          src={`${props.image}`} 
-          alt={props.name} />
-      </div>
-      <div className="row">
-        <div className="card-body col-9">
-          <h5 className="card-title">{props.name}</h5>
-          <p className="card-text">{props.description}</p>
-        </div>
-        <div className="float-end col-2" >
-          { currentUser != null ? <button onClick = {clickPostHandler} className="btn btn-lg btn-primary mt-4 rounded-pill">Join</button> : <p></p>}
-        </div>
-      </div>
-    </div>
+        <Link to={`/group/${props._id}`} style={{color: 'black', textDecoration: 'none' }}>
+          <div className="card my-3">
+            <div className="my-2">
+              <img
+                className="card-img mt-2"
+                src={`${props.image}`}
+                alt={props.name} />
+            </div>
+            <div className="row">
+              <div className="card-body col-9">
+                <h5 className="card-title">{props.name}</h5>
+                <p className="card-text">{props.description}</p>
+              </div>
+              <div className="float-end col-2" >
+                { currentUser != null ? <button onClick = {clickPostHandler} className="btn btn-lg btn-primary mt-4 rounded-pill">Join</button> : <p></p>}
+              </div>
+            </div>
+          </div>
+        </Link>
     );
 };
 export default GroupCard;

--- a/src/components/groups/groupSuggestionsItem.tsx
+++ b/src/components/groups/groupSuggestionsItem.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 import GroupType from "../../modules/groupType";
+import {Link} from "react-router-dom";
 
 const GroupSuggestionsItem = (group: GroupType) => {
     return (
-        <span className={"list-group-item"}>
-            <img 
-                className="rounded-circle" height={48} width={48}
-                src={`${group.image}`}
-                alt={group.name}
-                key={group.name}
-            />
+        <Link to={`/group/${group._id}`} style={{color: 'black', textDecoration: 'none' }}>
+            <span className={"list-group-item"}>
+              <img
+                  className="rounded-circle" height={48} width={48}
+                  src={`${group.image}`}
+                  alt={group.name}
+                  key={group.name}
+              />
             <span> {group.name} </span>
         </span>
+        </Link>
+
     );
 };
 

--- a/src/components/groups/groupsList.tsx
+++ b/src/components/groups/groupsList.tsx
@@ -1,9 +1,17 @@
 import React from "react";
-import groups from "../../data/users/groupsData"
 import GroupType from "../../modules/groupType";
 import GroupCard from "./groupCard";
+import {getAllGroups} from "../../services/group-services";
 
 const GroupsList = () => {
+  const [groups, setGroups] = React.useState([]);
+  React.useEffect(() => {
+    const fetchGroups = async () => {
+      const allGroups = await getAllGroups();
+      setGroups(allGroups);
+    }
+    fetchGroups();
+  }, []);
   return (
       <div className="card-deck row mx-5">
         {

--- a/src/components/posts/new-post-window.tsx
+++ b/src/components/posts/new-post-window.tsx
@@ -6,7 +6,7 @@ import {createPost} from "../../reducers/posts-reducer";
 import PostType from "../../modules/postType";
 import { createPostWithRecipe } from "../../services/post-services";
 import Select from 'react-select';
-import groups from "../../data/users/groupsData";
+import {getAllGroups} from "../../services/group-services";
 
 interface GroupOption {
   value: number,
@@ -16,6 +16,14 @@ interface GroupOption {
 const NewPostWindow = (props : RecipeType) => {
   let [postCaption, setPostCaption] = useState('');
   let [postGroup, setPostGroup] = useState('');
+  const [groups, setGroups] = React.useState([]);
+  React.useEffect(() => {
+    const fetchGroups = async () => {
+      const allGroups = await getAllGroups();
+      setGroups(allGroups);
+    }
+    fetchGroups();
+  }, []);
   const dispatch = useDispatch();
 
   let data: GroupOption[] = [];
@@ -48,7 +56,6 @@ const NewPostWindow = (props : RecipeType) => {
       recipe: props,
     });
     dispatch((createPost(newPost)));
-    
   }
   return (
       <div className="row">

--- a/src/components/profile/groupSection/followingGroups.tsx
+++ b/src/components/profile/groupSection/followingGroups.tsx
@@ -1,21 +1,34 @@
 import React from "react";
 import GroupSuggestionsItem from "../../groups/groupSuggestionsItem";
-import groups from "../../../data/users/groupsData";
 import GroupType from "../../../modules/groupType";
+import {getGroupsByUserId} from "../../../services/group-members-services";
 
-const FollowingGroups = ({user}) => {    
+const FollowingGroups = ({user}) => {
+
+  const [results, setResults] = React.useState<any>([]);
+  React.useEffect(() => {
+    const fetchResults = async () => {
+      if (user) {
+        const allGroupID = await getGroupsByUserId(user && user._id);
+        setResults(allGroupID);
+      }
+    }
+    fetchResults();
+  });
+
     return (
+        user ?
         <>
-            <h2> Groups {user.username} follows </h2>
+            <h2> Groups {user && user.username} follows </h2>
             <div className="list-group mb-1">
                 {
-                    groups.map((group : GroupType) => {
+                  results.map((group : GroupType) => {
                     return (
                         <GroupSuggestionsItem key={group._id} {...group} />                
                     );
                 })}
             </div>
-        </>
+        </> : <p>User not logged in</p>
     );
 };
 

--- a/src/components/profile/peopleSection/personCard.tsx
+++ b/src/components/profile/peopleSection/personCard.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import UserType from "../../../modules/userType";
+import {Link} from "react-router-dom";
 
 const PersonCard = (user: UserType) => {    
     return (
+        <Link to={`/profile/${user._id}`} style={{color: 'black', textDecoration: 'none' }}>
         <span className={"list-group-item"}>
             <img 
                 className="rounded-circle" height={48} width={48}
@@ -12,6 +14,7 @@ const PersonCard = (user: UserType) => {
             />
             <span> {user.name} </span>
         </span>
+        </Link>
     );
 };
 

--- a/src/data/users/groupsData.ts
+++ b/src/data/users/groupsData.ts
@@ -2,19 +2,19 @@ import GroupType from '../../modules/groupType';
 
 const groups : Array<GroupType> = [
     {
-      "_id": 1,
+      "_id": "1",
       "name": "Vegan",
       "image": "/groupImages/vegan.jpg",
       "description": "This is a group for those that are interested in Vegetarian and Vegan recipes or who are looking for good healthy recipes."
     }, 
     {
-        "_id": 2,
+        "_id": "2",
         "name": "Pasta Lovers",
         "image": "/groupImages/pastaLovers.jpg",
         "description": "This a group created by pasta lovers for pasta lovers! Here you will find delicious and yummy pictures, recipes and more!"
     },
     {
-      "_id": 3,
+      "_id": "3",
       "name": "Subtle Asian Eats",
       "image": "/groupImages/subtleAsianEats.jpg",
       "description": "You've laughed at the memes, you've found love, but let's be honest, food is one of the most pivotal parts of Asian Culture. Post up our favorite Asian food pics and invite any other Asian foodies you know!!"

--- a/src/modules/groupType.ts
+++ b/src/modules/groupType.ts
@@ -1,5 +1,5 @@
 export default interface GroupType {
-  _id: number,
+  _id: string,
   name: string,
   image: string,
   description: string

--- a/src/pages/profilePage.tsx
+++ b/src/pages/profilePage.tsx
@@ -80,7 +80,7 @@ const ProfilePage = (user: UserType) => {
               <PersonalInfo user={user} />
             </TabPane>
             <TabPane tabId="groups">
-              <FollowingGroups user={user} />
+              <FollowingGroups user={currentUser} />
             </TabPane>
             <TabPane tabId="following">
               <FollowingPeople user={user} />

--- a/src/reducers/group-members-reducer.tsx
+++ b/src/reducers/group-members-reducer.tsx
@@ -40,7 +40,7 @@ async (userId: string) => {
 export const createNewGroupMember = createAsyncThunk(
 'groupMembers/createNewGroupMember',
 async (groupMember: GroupMember) => {
-    const newGroupMember = await createGroupMember(groupMember);
+    const newGroupMember = await createGroupMember(groupMember.groupId, groupMember.userId);
     return newGroupMember;
 });
 

--- a/src/services/group-members-services.ts
+++ b/src/services/group-members-services.ts
@@ -1,13 +1,16 @@
 import axios from 'axios';
 
 const SERVER_API_URL = process.env.REACT_APP_SERVER_API_URL;
-const GROUPS_URL = `${SERVER_API_URL}/groups`;
 const GROUP_MEMS_URL = `${SERVER_API_URL}/group-members`;
 
 const api = axios.create({ withCredentials: true });
 
-export const createGroupMember = async (groupMember) => {
+export const createGroupMember = async (group: string, user: string) => {
   try {
+    const groupMember = {
+      group,
+      user
+    }
     const response = await api.post(`${GROUP_MEMS_URL}`, groupMember);
     return response.data;
   } catch (error) {
@@ -28,8 +31,7 @@ export const getGroupMembersByGroupId = async (groupId) => {
 
 export const getGroupsByUserId = async (userId) => {
   try {
-    console.log("INSIDE TRY", `${GROUPS_URL}/${userId}`);
-    const response = await api.get(`${GROUPS_URL}/${userId}`);
+    const response = await api.get(`${GROUP_MEMS_URL}/user/${userId}`);
     return response.data;
   } catch (error) {
     console.error(error);

--- a/src/services/group-members-services.ts
+++ b/src/services/group-members-services.ts
@@ -11,8 +11,8 @@ export const createGroupMember = async (groupMember) => {
     const response = await api.post(`${GROUP_MEMS_URL}`, groupMember);
     return response.data;
   } catch (error) {
-    console.error(error);
-    throw error;
+    console.error("Unable to join group: ", error);
+    return null;
   }
 };
 
@@ -28,6 +28,7 @@ export const getGroupMembersByGroupId = async (groupId) => {
 
 export const getGroupsByUserId = async (userId) => {
   try {
+    console.log("INSIDE TRY", `${GROUPS_URL}/${userId}`);
     const response = await api.get(`${GROUPS_URL}/${userId}`);
     return response.data;
   } catch (error) {

--- a/src/services/post-services.ts
+++ b/src/services/post-services.ts
@@ -7,6 +7,10 @@ export const createPostWithRecipe = async ({post, recipe}) => {
 
   console.log(post);
   console.log(recipe);
+  console.log("URL IS:", `${POSTS_URL}`, {
+    post,
+    recipe
+  });
 
   try {
     const response = await api.post(`${POSTS_URL}`, {

--- a/src/services/post-services.ts
+++ b/src/services/post-services.ts
@@ -7,10 +7,6 @@ export const createPostWithRecipe = async ({post, recipe}) => {
 
   console.log(post);
   console.log(recipe);
-  console.log("URL IS:", `${POSTS_URL}`, {
-    post,
-    recipe
-  });
 
   try {
     const response = await api.post(`${POSTS_URL}`, {


### PR DESCRIPTION
- changed route to retrieve a user's groups they're in from ".../api/groups/{user_id}" to ".../api/group-members/user/{user_id}"
-  changed schema for groupMembers for id to be a string to support the objectIDs from node
- moved creation of new groupMember to services
- you can now see what groups a user is in on their profile (only works for currentUser tho)
- made big group card, small group card, and small profile card clickable to route to their respective subpages